### PR TITLE
add: umami tracker script name change support

### DIFF
--- a/src/components/biz/Meta/footer.tsx
+++ b/src/components/biz/Meta/footer.tsx
@@ -37,7 +37,7 @@ export const MetaFooter = memo(() => {
           )
         }
 
-        if (analyze.umami.url && analyze.umami.id) {
+        if (analyze.umami.url && analyze.umami.id && analyze.umami.jsname) {
           tags.push(
             <script
               async
@@ -45,7 +45,7 @@ export const MetaFooter = memo(() => {
               defer
               data-website-id={analyze.umami.id}
               data-cache="true"
-              src={`${analyze.umami.url.replace(/\/$/, '')}/umami.js`}
+              src={`${analyze.umami.url.replace(/\/$/, '')}/${analyze.umami.jsname}.js`}
             ></script>,
           )
         }

--- a/src/configs.default.ts
+++ b/src/configs.default.ts
@@ -163,6 +163,7 @@ export const defaultConfigs = {
       umami: {
         id: '',
         url: '',
+        jsname: 'umami',
       },
     },
     donate: {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -12,6 +12,7 @@ interface Function {
     umami: {
       url: string
       id: string
+      jsname: string
     }
   }
 


### PR DESCRIPTION
考虑到[部分广告拦截器（如 uBlock Origin）阻拦了 Umami 脚本](https://github.com/umami-software/umami/issues/987)
Umami 官方在 1.26.0 版本开始，提供 `TRACKER_SCRIPT_NAME` 变量允许用户修改自己统计脚本的名字以应对广告拦截器的拦截。
本 PR 尝试在 kami 的配置文件中添加 `jsname` 变量，允许写入自己的脚本名，以应对统计脚本名非标准 （`umami.js`）的情况。

另附解决拦截问题 umami 侧的方法：
https://uaxk.com/umami-js-name/