### PR TITLE
fix(comment): highlight style flaws

### DIFF
--- a/src/components/widgets/Comment/index.module.css
+++ b/src/components/widgets/Comment/index.module.css
@@ -166,6 +166,8 @@
 
 .highlight {
   animation: highlight 1s ease;
+  padding: 16px 0 16px 16px !important;
+  margin-left: -16px;
 
   @apply rounded-sm animate-fill-both;
 }


### PR DESCRIPTION
### Description

修补了评论区在hover `@xx` 时对应子评论highlight的细微样式问题


### Additional context

**Origin**

<img width="747" alt="image" src="https://user-images.githubusercontent.com/62133302/198251554-30a3fafd-f12f-4827-a4cb-1ff603ba4be6.png">

**Now**

<img width="787" alt="image" src="https://user-images.githubusercontent.com/62133302/198251604-f3ffa7d6-61c0-4a8c-b796-d8efb3f12432.png">

