### PR TITLE
fix(comment): css causing styling shifts

### DIFF
--- a/src/components/widgets/Comment/index.module.css
+++ b/src/components/widgets/Comment/index.module.css
@@ -67,7 +67,9 @@
 .comment {
   .inner {
     display: flex;
-    padding: 16px 0;
+    padding: 16px 32px 16px 16px;
+    margin-left: -16px;
+    margin-right: -16px;
 
     .comment-avatar {
       position: relative;
@@ -166,9 +168,6 @@
 
 .highlight {
   animation: highlight 1s ease;
-  padding: 16px 32px 16px 16px !important;
-  margin-left: -16px;
-  margin-right: -16px;
 
   @apply rounded-sm animate-fill-both;
 }


### PR DESCRIPTION
### Description

修复评论区样式变化的问题

似乎在 `.highlight` 再应用那个样式没有什么必要，并且这样的写法会导致某个地方的宽度变化 ~~（似乎是）~~ 我不太清楚如何去修复那个问题，只好将 highlight 应用的样式放回 inner 就好了 这样应该不仅可以解决这个问题应该也可以~~不需要再计算样式吧（瞎猜~~

## Linked Issues

fix #1440