### PR TITLE
fix: data display exceptions during initialization

### DIFF
--- a/packages/kami-design/components/Overlay/index.tsx
+++ b/packages/kami-design/components/Overlay/index.tsx
@@ -18,14 +18,13 @@ interface OverLayProps {
   darkness?: number
   blur?: boolean
   zIndex?: number
+  stopPropagation?: boolean
 }
 
 export type OverlayProps = OverLayProps & {
   show: boolean
   children?: ReactNode
-
   zIndex?: number
-
   standaloneWrapperClassName?: string
 }
 
@@ -35,10 +34,10 @@ const OverLay: FC<OverlayProps> = (props) => {
     show,
     blur,
     center,
-
     darkness,
     standaloneWrapperClassName,
     zIndex,
+    stopPropagation,
   } = props
   const isClient = useIsClient()
 
@@ -108,7 +107,12 @@ const OverLay: FC<OverlayProps> = (props) => {
               : undefined
           }
         >
-          <div onClick={stopEventDefault} tabIndex={-1}>
+          <div
+            onClick={(e) => {
+              stopPropagation ? e.stopPropagation() : stopEventDefault(e)
+            }}
+            tabIndex={-1}
+          >
             {props.children}
           </div>
         </div>

--- a/src/components/in-page/Home/section.tsx
+++ b/src/components/in-page/Home/section.tsx
@@ -110,7 +110,7 @@ const _Sections: FC<AggregateTop> = ({ notes, posts }) => {
         }, [])}
       />
       <SectionCard
-        title={`点赞 (${like})`}
+        title={`点赞 (${like ?? 0})`}
         desc={'如果你喜欢的话点个赞呗'}
         src={useMemo(() => getRandomUnRepeatImage(), [])}
         href={'/like_this'}

--- a/src/pages/recently/index.tsx
+++ b/src/pages/recently/index.tsx
@@ -138,7 +138,7 @@ const RecentlyPage: NextPage = () => {
     }
 
     if (inView && hasNext) {
-      setFetchBefore(data[data.length - 1].id)
+      setFetchBefore(data[data.length - 1]?.id)
     }
   }, [data, hasNext, inView, loading])
 

--- a/src/pages/recently/index.tsx
+++ b/src/pages/recently/index.tsx
@@ -161,6 +161,9 @@ const RecentlyPage: NextPage = () => {
         fixedWidth: true,
         useRootPortal: true,
       },
+      overlayProps: {
+        stopPropagation: true,
+      },
       component: (
         <>
           <p className="!mt-4 leading-6 whitespace-pre-line break-all">


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

初始化博客完成后，主页和动态的一些数据无法正确显示

### Additional context
![one](https://user-images.githubusercontent.com/89030875/211205520-b7812123-f782-4bbc-b011-63a2015e2e9d.jpg)

![two](https://user-images.githubusercontent.com/89030875/211205540-0b1613dd-1617-4563-96b3-644be81697d6.jpg)

