### PR TITLE
feat: improve localized content experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,17 @@ interface LinkCardProps {
 
 [配置项](https://mx-docs.shizuri.net/deploy/kami#%E6%9B%B4%E4%B8%BA%E8%AF%A6%E7%BB%86%E7%9A%84%E9%85%8D%E7%BD%AE%E9%A1%B9)
 
+### 多语言主题覆盖
+
+保留基础片段 `theme/kami`，并在 Core 的「区块与片段」中按需新增
+`theme/kami.en` 与 `theme/kami.ja`。Kami 会请求
+`aggregate?theme=kami&lang=<locale>`，由 Core 将对应语言片段深度合并到基础
+主题。
+
+覆盖片段只需要包含变更字段。例如可在其中配置 `site.title`、
+`site.description`、`site.introduction`，以及菜单、首页分区标题、页脚和社交
+提示等已有主题文本；未设置的字段继续使用基础主题或 Core 数据。
+
 ## Notice
 
 可以在此基础上保留署名进行二次创作，但是禁止用于以盈利为目的一切活动。

--- a/config.init.yaml
+++ b/config.init.yaml
@@ -1,6 +1,10 @@
 name: kami
 
 site:
+  # 可在 theme/kami.en、theme/kami.ja 覆盖以下站点文案；未配置时回退到 Core 数据。
+  title: null
+  description: null
+  introduction: null
   favicon: /favicon.svg
   # 开屏图 svg 标签，注意 XSS
   logo_svg: null

--- a/src/atoms/collections/note.ts
+++ b/src/atoms/collections/note.ts
@@ -7,10 +7,19 @@ import type { FetchOption } from '~/atoms/types'
 import type { WithMeta } from '~/types/api-client'
 import { apiClient } from '~/utils/client'
 import { isLikedBefore, setLikeId } from '~/utils/cookie'
+import {
+  type LocalizedContent,
+  withContentLocale,
+} from '~/utils/translation'
 
 import { createCollection } from './utils/base'
 
-type NoteModelWithId = WithMeta<NoteModel> & { id: string; [key: string]: any }
+export type NoteModelWithId = WithMeta<NoteModel> &
+  LocalizedContent & {
+    id: string
+    [key: string]: any
+  }
+const localizedKey = (id: string, locale: string) => `${id}:${locale}`
 
 interface NoteCollection {
   relationMap: Map<
@@ -18,8 +27,11 @@ interface NoteCollection {
     [Partial<NoteModelWithId> | undefined, Partial<NoteModelWithId> | undefined]
   >
   nidToIdMap: Map<number, string>
+  localizedData: Map<string, NoteModelWithId>
   likeIdList: Set<string>
   get(id: string | number): NoteModelWithId | undefined
+  getLocalized(id: string | number, locale: string): NoteModelWithId | undefined
+  cacheLocalized(data: NoteModelWithId, locale: string): void
   like(
     id: number,
     messages?: { alreadyLiked: string; thanksLike: string },
@@ -34,7 +46,7 @@ interface NoteCollection {
       isDeleted?: boolean | undefined
     }
   >
-  fetchLatest(): Promise<ModelWithLiked<NoteModelWithId>>
+  fetchLatest(lang?: string): Promise<ModelWithLiked<NoteModelWithId>>
   bookmark(id: string): Promise<void>
 }
 
@@ -46,10 +58,13 @@ export const useNoteCollection = createCollection<NoteModelWithId, NoteCollectio
       [Partial<NoteModelWithId> | undefined, Partial<NoteModelWithId> | undefined]
     >()
     const nidToIdMap = new Map<number, string>()
+    const localizedData = new Map<string, NoteModelWithId>()
     const likeIdList = new Set<string>()
+    const latestLocaleByResource = new Map<string, string>()
 
     relationMap[immerable] = true
     nidToIdMap[immerable] = true
+    localizedData[immerable] = true
     likeIdList[immerable] = true
 
     const getCollection = () => getState().data
@@ -57,6 +72,7 @@ export const useNoteCollection = createCollection<NoteModelWithId, NoteCollectio
     return {
       relationMap,
       nidToIdMap,
+      localizedData,
       likeIdList,
       get(id: string | number) {
         if (typeof id === 'string') {
@@ -65,6 +81,21 @@ export const useNoteCollection = createCollection<NoteModelWithId, NoteCollectio
           const realId = getState().nidToIdMap.get(id)
           return realId ? getCollection().get(realId) : undefined
         }
+      },
+      getLocalized(id, locale) {
+        const realId =
+          typeof id === 'string' ? id : getState().nidToIdMap.get(id)
+        return realId
+          ? getState().localizedData.get(localizedKey(realId, locale))
+          : undefined
+      },
+      cacheLocalized(data, locale) {
+        const localized = withContentLocale(data, locale)
+        setState((state) => {
+          state.localizedData.set(localizedKey(localized.id, locale), localized)
+          state.data.set(localized.id, localized)
+          state.nidToIdMap.set(localized.nid, localized.id)
+        })
       },
       async like(
         id: number,
@@ -138,7 +169,12 @@ export const useNoteCollection = createCollection<NoteModelWithId, NoteCollectio
       ) {
         const state = getState()
         const collection = getCollection()
+        const locale = options.lang ?? 'zh'
         if (!options.force) {
+          const cachedLocalized = state.getLocalized(id, locale)
+          if (cachedLocalized) {
+            return cachedLocalized
+          }
           if (typeof id === 'string' && collection.has(id)) {
             return collection.get(id)!
           } else if (typeof id === 'number') {
@@ -148,35 +184,46 @@ export const useNoteCollection = createCollection<NoteModelWithId, NoteCollectio
             }
           }
         }
+        const resourceKey = String(id)
+        latestLocaleByResource.set(resourceKey, locale)
         const data =
-          typeof id === 'number' && options.lang != null
+          typeof id === 'number'
             ? await apiClient.note.getNoteByNid(id, {
                 password,
                 lang: options.lang,
               })
-            : await apiClient.note.getNoteById(
-                id as number,
-                password as string,
-              )
-        const noteData = data.data as NoteModelWithId
-        state.add(noteData)
+            : await apiClient.note.proxy(id).get<any>({
+                params: { password, lang: options.lang },
+              })
+        const noteData = (data.data?.id ? data.data : data) as NoteModelWithId
+        const localized = withContentLocale(noteData, locale)
         setState((state) => {
-          state.nidToIdMap.set(noteData.nid, noteData.id)
-          state.relationMap.set(noteData.id, [data.prev, data.next])
+          state.localizedData.set(localizedKey(localized.id, locale), localized)
+          state.nidToIdMap.set(localized.nid, localized.id)
+          state.relationMap.set(localized.id, [data.prev, data.next])
+          if (latestLocaleByResource.get(resourceKey) === locale) {
+            state.data.set(localized.id, localized)
+          }
         })
 
-        return noteData
+        return localized
       },
-      async fetchLatest() {
-        const data = await apiClient.note.getLatest()
-        const noteData = data.data as ModelWithLiked<NoteModelWithId>
-        getState().add(noteData)
+      async fetchLatest(lang = 'zh') {
+        const data = await apiClient.note.proxy.latest.get<any>({
+          params: { lang },
+        })
+        const noteData = (data.data?.id
+          ? data.data
+          : data) as ModelWithLiked<NoteModelWithId>
+        const localized = withContentLocale(noteData, lang)
         setState((state) => {
-          state.nidToIdMap.set(noteData.nid, noteData.id)
-          state.relationMap.set(noteData.id, [data.prev, data.next])
+          state.localizedData.set(localizedKey(localized.id, lang), localized)
+          state.data.set(localized.id, localized)
+          state.nidToIdMap.set(localized.nid, localized.id)
+          state.relationMap.set(localized.id, [data.prev, data.next])
         })
 
-        return noteData
+        return localized
       },
       async bookmark(id: string) {
         const note = getState().get(id)

--- a/src/atoms/collections/post.ts
+++ b/src/atoms/collections/post.ts
@@ -1,13 +1,23 @@
+import { immerable } from 'immer'
+
 import type { ModelWithLiked, PostModel } from '@mx-space/api-client'
 
 import type { WithMeta } from '~/types/api-client'
 import { apiClient } from '~/utils/client'
+import {
+  type LocalizedContent,
+  withContentLocale,
+} from '~/utils/translation'
 
 import { createCollection } from './utils/base'
 
-type PostModelWithMeta = WithMeta<PostModel>
+export type PostModelWithMeta = WithMeta<PostModel> & LocalizedContent
+const localizedKey = (id: string, locale: string) => `${id}:${locale}`
 
 interface IPostCollection {
+  localizedData: Map<string, PostModelWithMeta>
+  getLocalized(id: string, locale: string): PostModelWithMeta | undefined
+  cacheLocalized(data: PostModelWithMeta, locale: string): void
   fetchBySlug(
     category: string,
     slug: string,
@@ -17,18 +27,41 @@ interface IPostCollection {
 }
 export const usePostCollection = createCollection<PostModelWithMeta, IPostCollection>(
   'post',
-  (setState) => {
+  (setState, getState) => {
+    const localizedData = new Map<string, PostModelWithMeta>()
+    localizedData[immerable] = true
+    const latestLocaleByResource = new Map<string, string>()
     return {
+      localizedData,
+      getLocalized(id, locale) {
+        return getState().localizedData.get(localizedKey(id, locale))
+      },
+      cacheLocalized(data, locale) {
+        const localized = withContentLocale(data, locale)
+        setState((state) => {
+          state.localizedData.set(localizedKey(localized.id, locale), localized)
+          state.data.set(localized.id, localized)
+        })
+      },
       async fetchBySlug(category, slug, lang) {
+        const locale = lang === 'original' ? 'zh' : (lang ?? 'zh')
+        const resourceKey = `${category}/${slug}`
+        latestLocaleByResource.set(resourceKey, locale)
         const data = await apiClient.post.getPost(
           category,
           encodeURIComponent(slug),
           { lang: lang === 'original' ? undefined : lang },
         )
+        const localized = withContentLocale(data, locale)
         setState((state) => {
-          state.data.set(data.id, data)
+          state.localizedData.set(localizedKey(localized.id, locale), localized)
+          // Components outside the locale-aware detail view still read `data`.
+          // Only the most recently requested locale may update that fallback.
+          if (latestLocaleByResource.get(resourceKey) === locale) {
+            state.data.set(localized.id, localized)
+          }
         })
-        return data
+        return localized
       },
       up(id: string) {
         setState((state) => {

--- a/src/components/app/Meta/head.tsx
+++ b/src/components/app/Meta/head.tsx
@@ -10,9 +10,9 @@ import { loadScript } from '~/utils/load-script'
 
 export const DynamicHeadMeta: FC = memo(() => {
   const initialData = useInitialData()
-  const title = initialData.seo.title
 
   const themeConfig = useKamiConfig()
+  const title = themeConfig.site.title || initialData.seo.title
   const favicon = themeConfig.site.favicon || '/favicon.svg'
 
   const { dark: darkBg, light: lightBg } = themeConfig.site.background.src

--- a/src/components/app/Seo/index.tsx
+++ b/src/components/app/Seo/index.tsx
@@ -5,7 +5,7 @@ import type { OpenGraph } from 'next-seo/lib/types'
 import type { FC } from 'react'
 import { createElement, memo } from 'react'
 
-import { useInitialData } from '~/hooks/app/use-initial-data'
+import { useInitialData, useKamiConfig } from '~/hooks/app/use-initial-data'
 import { useRandomImage } from '~/hooks/app/use-kami-theme'
 
 type SEOProps = {
@@ -31,13 +31,16 @@ export const Seo: FC<SEOProps> = memo((props) => {
     seo,
     user,
   } = useInitialData()
-  const nextTitle = `${title} - ${seo.title}`
+  const config = useKamiConfig()
+  const siteTitle = config.site.title || seo.title
+  const siteDescription = config.site.description || seo.description
+  const nextTitle = `${title} - ${siteTitle}`
 
   const [randomImage] = useRandomImage()
 
   return createElement(NextSeo, {
     title,
-    titleTemplate: `%s - ${seo.title}`,
+    titleTemplate: `%s - ${siteTitle}`,
     openGraph: merge(
       {
         profile: {
@@ -45,8 +48,8 @@ export const Seo: FC<SEOProps> = memo((props) => {
         },
         type: 'article',
         locale: 'zh-cn',
-        site_name: seo.title || '',
-        description: description || seo.description || user.introduce || '',
+        site_name: siteTitle || '',
+        description: description || siteDescription || user.introduce || '',
         article: {
           authors: [user.name],
         },
@@ -56,14 +59,14 @@ export const Seo: FC<SEOProps> = memo((props) => {
             ? [
                 {
                   url: image || randomImage,
-                  alt: `${title} - ${seo.title}`,
+                  alt: `${title} - ${siteTitle}`,
                 },
               ]
             : void 0,
       } as OpenGraph,
       openGraph,
     ),
-    description: description || seo.description || user.introduce || '',
+    description: description || siteDescription || user.introduce || '',
     twitter: {
       cardType: 'summary',
       site: webUrl,

--- a/src/components/in-page/Home/intro.tsx
+++ b/src/components/in-page/Home/intro.tsx
@@ -17,6 +17,7 @@ const wrapperProps = { className: '!w-full !h-full !border-none !shadow-none' }
 export const HomeIntro: FC = () => {
   const { doAnimation } = useHomePageViewContext()
   const user = useUserStore((state) => state.master)
+  const config = useThemeConfig()
 
   if (!user) {
     return null
@@ -40,7 +41,7 @@ export const HomeIntro: FC = () => {
           appear={doAnimation}
           className="text-theme-gray-1 mt-2 leading-7"
         >
-          {user.introduce || ''}
+          {config.site.introduction || user.introduce || ''}
         </TextUpTransitionView>
 
         <Social />

--- a/src/components/in-page/Home/random-say.tsx
+++ b/src/components/in-page/Home/random-say.tsx
@@ -6,28 +6,34 @@ import useSWR from 'swr'
 import { AnimateChangeInHeight } from '~/components/ui/AnimateChangeInHeight'
 import { TextUpTransitionView } from '~/components/ui/Transition/TextUpTransitionView'
 import { useIsClient } from '~/hooks/common/use-is-client'
+import { useLocaleFromContext } from '~/provider/locale-context'
 import { apiClient } from '~/utils/client'
 
-let isLoaded = false
 export const HomeRandomSay: FC = memo(() => {
   const t = useTranslations('home')
+  const locale = useLocaleFromContext()
   const { data: sayData, mutate } = useSWR(
-    'home-say',
+    ['home-say', locale],
     () =>
-      apiClient.say.getRandom().then(({ data }) => {
-        if (!data) return undefined
-        return { text: data.text, author: data.author, source: data.source }
-      }),
+      apiClient.say.proxy.random
+        .get<{
+          data: {
+            text: string
+            author: string | null
+            source: string | null
+          } | null
+        }>({ params: { lang: locale } })
+        .then(({ data }) => {
+          if (!data) return undefined
+          return { text: data.text, author: data.author, source: data.source }
+        }),
     {
       fallbackData: undefined as
         | { text: string; author: string | null; source: string | null }
         | undefined,
       refreshInterval: 10_000,
       revalidateOnFocus: false,
-      revalidateOnMount: !isLoaded,
-      onSuccess() {
-        isLoaded = true
-      },
+      revalidateOnMount: true,
     },
   )
 

--- a/src/components/in-page/Post/PostRelated.tsx
+++ b/src/components/in-page/Post/PostRelated.tsx
@@ -5,10 +5,15 @@ import { shallow } from 'zustand/shallow'
 
 import { usePostCollection } from '~/atoms/collections/post'
 import { Divider } from '~/components/ui/Divider'
+import { useLocaleFromContext } from '~/provider/locale-context'
 
 export const PostRelated = memo<{ id: string }>((props) => {
   const t = useTranslations('post')
-  const post = usePostCollection((state) => state.data.get(props.id), shallow)
+  const locale = useLocaleFromContext()
+  const post = usePostCollection(
+    (state) => state.getLocalized(props.id, locale) ?? state.data.get(props.id),
+    shallow,
+  )
   if (!post) {
     return null
   }

--- a/src/components/in-page/Translation/index.tsx
+++ b/src/components/in-page/Translation/index.tsx
@@ -1,0 +1,128 @@
+import type { FC } from 'react'
+import { useTranslations } from 'next-intl'
+
+import { Banner } from '~/components/ui/Banner'
+import { enabledLocaleSet } from '~/i18n/config'
+import { useRouter } from '~/i18n/navigation'
+import { useLocaleFromContext } from '~/provider/locale-context'
+import { getContentTranslation } from '~/utils/translation'
+
+const normalizeLocale = (value: string | undefined) =>
+  value?.trim().toLowerCase().replace(/_/g, '-').split('-')[0]
+
+const getLanguageNameKey = (locale: string) => `language.${locale}`
+
+const useTranslationLanguages = (content: unknown) => {
+  const translation = getContentTranslation(content)
+  const locale = useLocaleFromContext()
+  const languages = Array.from(
+    new Set(
+      [translation.sourceLang, ...translation.availableTranslations]
+        .map(normalizeLocale)
+        .filter(
+          (language): language is string =>
+            !!language && enabledLocaleSet.has(language),
+        ),
+    ),
+  )
+
+  return { locale, languages, translation }
+}
+
+export const TranslationLanguageSelector: FC<{ content: unknown }> = ({
+  content,
+}) => {
+  const t = useTranslations('translation')
+  const router = useRouter()
+  const { locale, languages, translation } = useTranslationLanguages(content)
+
+  if (languages.length < 2) {
+    return null
+  }
+
+  const selectedLocale = languages.includes(locale) ? locale : ''
+  const sourceLang = normalizeLocale(translation.sourceLang)
+
+  return (
+    <label className="text-gray-1 inline-flex items-center gap-2 text-sm font-normal">
+      <span className="sr-only">{t('selectLanguage')}</span>
+      <select
+        aria-label={t('selectLanguage')}
+        className="bg-transparent cursor-pointer appearance-auto rounded border border-current/20 px-2 py-1"
+        value={selectedLocale}
+        onChange={(event) => {
+          const nextLocale = event.currentTarget.value
+          if (nextLocale !== locale) {
+            void router.push(router.asPath, {
+              locale: nextLocale,
+              scroll: false,
+            })
+          }
+        }}
+      >
+        {!selectedLocale && (
+          <option value="" disabled>
+            {t('originalContent', {
+              language: sourceLang
+                ? t(getLanguageNameKey(sourceLang))
+                : locale,
+            })}
+          </option>
+        )}
+        {languages.map((language) => (
+          <option key={language} value={language}>
+            {t(getLanguageNameKey(language))}
+          </option>
+        ))}
+      </select>
+    </label>
+  )
+}
+
+export const TranslationNotice: FC<{ content: unknown }> = ({ content }) => {
+  const t = useTranslations('translation')
+  const router = useRouter()
+  const { locale, translation } = useTranslationLanguages(content)
+  const sourceLang = normalizeLocale(translation.sourceLang)
+  const targetLang = normalizeLocale(translation.targetLang)
+
+  if (translation.isTranslated && sourceLang && targetLang) {
+    return (
+      <Banner type="info" placement="left" className="mb-6" showIcon={false}>
+        <div className="flex w-full flex-wrap items-center gap-x-3 gap-y-2">
+          <strong>{t('aiTranslation')}</strong>
+          <span>
+            {t(getLanguageNameKey(sourceLang))} →{' '}
+            {t(getLanguageNameKey(targetLang))}
+          </span>
+          {sourceLang !== locale && (
+            <button
+              type="button"
+              className="ml-auto underline underline-offset-2"
+              onClick={() =>
+                void router.push(router.asPath, {
+                  locale: sourceLang,
+                  scroll: false,
+                })
+              }
+            >
+              {t('viewOriginal')}
+            </button>
+          )}
+        </div>
+      </Banner>
+    )
+  }
+
+  if (sourceLang && sourceLang !== locale) {
+    return (
+      <Banner type="info" placement="left" className="mb-6" showIcon={false}>
+        <span>
+          {t('originalContent', { language: t(getLanguageNameKey(sourceLang)) })}
+        </span>
+      </Banner>
+    )
+  }
+
+  return null
+}

--- a/src/components/layouts/AppLayout.tsx
+++ b/src/components/layouts/AppLayout.tsx
@@ -8,7 +8,7 @@ import { MetaFooter } from '~/components/app/Meta/footer'
 import { DynamicHeadMeta } from '~/components/app/Meta/head'
 import { Loader } from '~/components/widgets/Loader'
 import { useRootTrackerListener } from '~/hooks/app/use-analyze'
-import { useInitialData } from '~/hooks/app/use-initial-data'
+import { useInitialData, useKamiConfig } from '~/hooks/app/use-initial-data'
 import { useResizeScrollEvent } from '~/hooks/app/use-resize-scroll-event'
 import { useRouterEvent } from '~/hooks/app/use-router-event'
 import { useScreenMedia } from '~/hooks/ui/use-screen-media'
@@ -21,6 +21,7 @@ export const AppLayout: FC = (props) => {
   useResizeScrollEvent()
   useRootTrackerListener()
   const initialData: AggregateRoot | null = useInitialData()
+  const config = useKamiConfig()
 
   useInsertionEffect(() => {
     loadStyleSheet(
@@ -32,8 +33,10 @@ export const AppLayout: FC = (props) => {
     <>
       <DynamicHeadMeta />
       <NextSeo
-        title={`${initialData.seo.title} · ${initialData.seo.description}`}
-        description={initialData.seo.description}
+        title={`${config.site.title || initialData.seo.title} · ${
+          config.site.description || initialData.seo.description
+        }`}
+        description={config.site.description || initialData.seo.description}
       />
 
       <div id="next">{props.children}</div>

--- a/src/components/layouts/ArticleLayout/index.tsx
+++ b/src/components/layouts/ArticleLayout/index.tsx
@@ -1,5 +1,5 @@
 import { clsx } from 'clsx'
-import type { DetailedHTMLProps, HTMLAttributes } from 'react'
+import type { DetailedHTMLProps, HTMLAttributes, ReactNode } from 'react'
 import { forwardRef, memo, useMemo } from 'react'
 
 import { BottomToUpTransitionView } from '~/components/ui/Transition/BottomToUpTransitionView'
@@ -13,6 +13,7 @@ export interface ArticleLayoutProps {
   subtitle?: string | string[]
   titleAnimate?: boolean
   subtitleAnimation?: boolean
+  titleMeta?: ReactNode
   delay?: number
 
   type?: 'post' | 'page'

--- a/src/components/layouts/ArticleLayout/title.tsx
+++ b/src/components/layouts/ArticleLayout/title.tsx
@@ -15,6 +15,7 @@ export const ArticleLayoutTitle = memo<{ animate?: boolean }>(
       type,
       id,
       subtitle,
+      titleMeta,
       subtitleAnimation = true,
     } = useArticleLayoutProps()
     const isLogged = useIsLogged()
@@ -46,6 +47,10 @@ export const ArticleLayoutTitle = memo<{ animate?: boolean }>(
             </a>
           ) : null}
         </h1>
+
+        {titleMeta && (
+          <div className="mt-3 flex justify-center">{titleMeta}</div>
+        )}
 
         {subtitle && (
           <h2>

--- a/src/components/layouts/NoteLayout.tsx
+++ b/src/components/layouts/NoteLayout.tsx
@@ -43,8 +43,9 @@ const bannerClassNames = {
 const dayjsLocaleMap = { zh: 'zh-cn', en: 'en', ja: 'ja' } as const
 
 const useNoteMetaBanner = (id: string) => {
+  const locale = useLocaleFromContext()
   const note = useNoteCollection((state) => {
-    const note = state.get(id)
+    const note = state.getLocalized(id, locale) ?? state.get(id)
     if (!note) return null
     return { meta: note.meta }
   }, shallow)
@@ -82,11 +83,20 @@ interface NoteLayoutProps {
   children?: ReactNode
 
   isPreview?: boolean
+  titleMeta?: ReactNode
 }
 
 export const NoteLayout = forwardRef<HTMLElement, NoteLayoutProps>(
   (props, ref) => {
-    const { date, id, title, tips, children, isPreview = false } = props
+    const {
+      date,
+      id,
+      title,
+      tips,
+      children,
+      isPreview = false,
+      titleMeta,
+    } = props
     const locale = useLocaleFromContext()
     const dateLocale = dayjsLocaleMap[locale] ?? 'en'
     // autocorrect: false
@@ -96,9 +106,15 @@ export const NoteLayout = forwardRef<HTMLElement, NoteLayoutProps>(
 
     const url = useAppStore((state) => state.appUrl)
 
-    const bookmark = useNoteCollection((state) => state.get(id)?.bookmark)
+    const bookmark = useNoteCollection(
+      (state) =>
+        state.getLocalized(id, locale)?.bookmark ?? state.get(id)?.bookmark,
+    )
     const isHide = useNoteCollection(
-      (state) => (state.get(id) as { hide?: boolean } | undefined)?.hide,
+      (state) => {
+        const note = state.getLocalized(id, locale) ?? state.get(id)
+        return (note as { hide?: boolean } | undefined)?.hide
+      },
     )
     const banner = useNoteMetaBanner(id)
     const onMarkToggle = useCallback(async () => {
@@ -225,6 +241,9 @@ export const NoteLayout = forwardRef<HTMLElement, NoteLayoutProps>(
                   </a>
                 ) : null}
               </h1>
+              {titleMeta && (
+                <div className="mt-3 flex justify-center">{titleMeta}</div>
+              )}
 
               {children}
             </div>

--- a/src/components/layouts/SiteLayout/Header/Header.tsx
+++ b/src/components/layouts/SiteLayout/Header/Header.tsx
@@ -29,7 +29,7 @@ export const Header: FC = () => {
     seo: { title, description },
   } = useInitialData()
   const {
-    site: { subtitle },
+    site: { subtitle, title: siteTitle, description: siteDescription },
   } = useKamiConfig()
   const isLogged = useIsLogged()
 
@@ -87,7 +87,8 @@ export const Header: FC = () => {
 
   const isClient = useIsClient()
 
-  const headerSubTitle = subtitle || description || ''
+  const headerTitle = siteTitle || title
+  const headerSubTitle = subtitle || siteDescription || description || ''
 
   // const headerSubTitle = ''
   if (!isClient) {
@@ -123,7 +124,7 @@ export const Header: FC = () => {
                   headerSubTitle && styles['title-has-sub'],
                 )}
               >
-                {title}
+                {headerTitle}
               </h1>
               {headerSubTitle && (
                 <h2 className={styles['subtitle']}>{headerSubTitle}</h2>

--- a/src/components/widgets/Search/index.tsx
+++ b/src/components/widgets/Search/index.tsx
@@ -49,6 +49,7 @@ export const SearchPanel: FC<SearchPanelProps> = (props) => {
     ([, , searchKeyword]) => {
       return apiClient.search.searchAll(
         searchKeyword,
+        { lang: locale },
       ) as unknown as Promise<SearchResultResponse>
     },
     {

--- a/src/configs.default.ts
+++ b/src/configs.default.ts
@@ -2,6 +2,9 @@
 export const defaultConfigs = {
   name: 'kami',
   site: {
+    title: null,
+    description: null,
+    introduction: null,
     favicon: '/favicon.svg',
     logoSvg: null,
     figure: null,

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -48,6 +48,18 @@
     "thanksLike": "Thanks for your like!",
     "randomSayBy": "Owner"
   },
+  "translation": {
+    "selectLanguage": "Select content language",
+    "aiTranslation": "AI Translation",
+    "viewOriginal": "View Original",
+    "originalContent": "Showing the original content ({language})",
+    "loading": "Switching language…",
+    "language": {
+      "zh": "Simplified Chinese",
+      "en": "English",
+      "ja": "Japanese"
+    }
+  },
   "topic": {
     "title": "Topics",
     "columnTitle": "Topic · {name}",

--- a/src/messages/ja.json
+++ b/src/messages/ja.json
@@ -48,6 +48,18 @@
     "thanksLike": "ありがとう！",
     "randomSayBy": "管理者"
   },
+  "translation": {
+    "selectLanguage": "コンテンツの言語を選択",
+    "aiTranslation": "AI 翻訳",
+    "viewOriginal": "原文を見る",
+    "originalContent": "原文を表示しています（{language}）",
+    "loading": "言語を切り替えています…",
+    "language": {
+      "zh": "簡体字中国語",
+      "en": "English",
+      "ja": "日本語"
+    }
+  },
   "topic": {
     "title": "トピック",
     "columnTitle": "トピック · {name}",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -48,6 +48,18 @@
     "thanksLike": "感谢喜欢！",
     "randomSayBy": "站长说"
   },
+  "translation": {
+    "selectLanguage": "选择内容语言",
+    "aiTranslation": "AI 翻译",
+    "viewOriginal": "查看原文",
+    "originalContent": "当前显示原文（{language}）",
+    "loading": "正在切换语言…",
+    "language": {
+      "zh": "简体中文",
+      "en": "English",
+      "ja": "日本語"
+    }
+  },
   "topic": {
     "title": "专栏",
     "columnTitle": "专栏 · {name}",

--- a/src/pages/[locale]/index.tsx
+++ b/src/pages/[locale]/index.tsx
@@ -8,24 +8,39 @@ import { HomePageViewProvider } from '~/components/in-page/Home/context'
 import { HomeIntro } from '~/components/in-page/Home/intro'
 import { HomeRandomSay } from '~/components/in-page/Home/random-say'
 import { HomeSections } from '~/components/in-page/Home/section'
+import { Loading } from '~/components/ui/Loading'
 import { useInitialData, useKamiConfig } from '~/hooks/app/use-initial-data'
-import { getLocaleFromContext, useRouter } from '~/i18n/navigation'
+import { getLocaleFromContext } from '~/i18n/navigation'
+import { useLocaleFromContext } from '~/provider/locale-context'
 import { omit } from '~/utils/_'
-import { apiClient, setRequestLocale } from '~/utils/client'
+import { apiClient } from '~/utils/client'
 import { Notice } from '~/utils/notice'
 
-const IndexView: NextPage<AggregateTop> = (props) => {
-  const router = useRouter()
-  const [aggregateTop, setAggregateTop] = useState<AggregateTop>(props)
+const fetchAggregateTop = (locale: string) =>
+  apiClient.aggregate.proxy.top.get<AggregateTop>({
+    params: { size: 5, lang: locale },
+  })
+
+type HomeAggregateTop = Omit<AggregateTop, 'says'>
+type LocalizedAggregateTop = HomeAggregateTop & { __contentLocale?: string }
+
+const IndexView: NextPage<LocalizedAggregateTop> = (props) => {
+  const locale = useLocaleFromContext()
+  const [aggregateTop, setAggregateTop] = useState<HomeAggregateTop>(props)
+  const [contentLocale, setContentLocale] = useState(props.__contentLocale)
 
   // Sync props into state when getInitialProps returns fresh data on client-side navigation
   useEffect(() => {
-    setAggregateTop(props)
-  }, [props])
+    if (props.__contentLocale === locale) {
+      setAggregateTop(props)
+      setContentLocale(props.__contentLocale)
+    }
+  }, [locale, props])
 
   const initData = useInitialData()
 
-  const { function: fn } = useKamiConfig()
+  const config = useKamiConfig()
+  const { function: fn } = config
   const { notification } = fn
   const doAnimation = Boolean(
     globalThis.history
@@ -59,20 +74,13 @@ const IndexView: NextPage<AggregateTop> = (props) => {
     }
   }, [notification?.welcome])
 
-  useEffect(() => {
-    const effectiveLocale = getLocaleFromContext({
-      pathname: router.pathname ?? '',
-      asPath: router.asPath ?? '',
-      query: router.query,
-    })
-    setRequestLocale(effectiveLocale)
-  }, [router.pathname, router.asPath, router.query])
-
   return (
     <main>
       <NextSeo
-        title={`${initData.seo.title} · ${initData.seo.description}`}
-        description={initData.seo.description}
+        title={`${config.site.title || initData.seo.title} · ${
+          config.site.description || initData.seo.description
+        }`}
+        description={config.site.description || initData.seo.description}
       />
       <HomePageViewProvider
         value={useMemo(() => ({ doAnimation }), [doAnimation])}
@@ -80,16 +88,21 @@ const IndexView: NextPage<AggregateTop> = (props) => {
         <HomeIntro />
 
         <HomeRandomSay />
-        <HomeSections {...aggregateTop} />
+        {contentLocale === locale ? (
+          <HomeSections {...aggregateTop} says={[]} />
+        ) : (
+          <Loading />
+        )}
       </HomePageViewProvider>
     </main>
   )
 }
 
-IndexView.getInitialProps = async () => {
-  const aggregateData = await apiClient.aggregate.getTop()
+IndexView.getInitialProps = async (ctx) => {
+  const locale = getLocaleFromContext(ctx)
+  const aggregateData = await fetchAggregateTop(locale)
 
-  return omit({ ...aggregateData }, ['says']) as any
+  return { ...omit({ ...aggregateData }, ['says']), __contentLocale: locale }
 }
 
 export default IndexView

--- a/src/pages/[locale]/notes/[id].tsx
+++ b/src/pages/[locale]/notes/[id].tsx
@@ -29,6 +29,10 @@ import { NoteFooterNavigationBarForMobile } from '~/components/in-page/Note/Note
 import { NoteMarkdownRender } from '~/components/in-page/Note/NoteMarkdownRender'
 import { NotePasswordConfrim } from '~/components/in-page/Note/NotePasswordConfirm'
 import { BanCopy } from '~/components/in-page/Note/WarningOverlay/ban-copy'
+import {
+  TranslationLanguageSelector,
+  TranslationNotice,
+} from '~/components/in-page/Translation'
 import { NoteLayout } from '~/components/layouts/NoteLayout'
 import { Banner } from '~/components/ui/Banner'
 import { ImageSizeMetaContext } from '~/components/ui/Image/context'
@@ -52,6 +56,7 @@ import type { WithMeta } from '~/types/api-client'
 import { isEqualObject, omit } from '~/utils/_'
 import { imagesRecord2Map } from '~/utils/images'
 import { getSummaryFromMd } from '~/utils/markdown'
+import { getContentLocale } from '~/utils/translation'
 import { noop } from '~/utils/utils'
 import { isDev } from '~/utils/env'
 
@@ -173,7 +178,8 @@ const NoteView: React.FC<{ id: string; locale?: string }> = memo((props) => {
   const dayjsLocale = dayjsLocaleMap[locale] ?? 'en'
   const intlLocale = intlLocaleMap[locale] ?? 'en-US'
   const note = useNoteCollection(
-    (state) => state.get(props.id) || (noop as NoteModelWithMeta),
+    (state) =>
+      state.getLocalized(props.id, locale) || (noop as NoteModelWithMeta),
   )
 
   const router = useRouter()
@@ -191,9 +197,9 @@ const NoteView: React.FC<{ id: string; locale?: string }> = memo((props) => {
 
   useEffect(() => {
     if (!noteCollection.relationMap.has(props.id)) {
-      noteCollection.fetchById(note.nid, undefined, { force: true })
+      noteCollection.fetchById(note.nid, undefined, { force: true, lang: locale })
     }
-  }, [note.nid, props.id])
+  }, [locale, note.nid, props.id])
 
   useSetHeaderShare(note.title)
   useUpdateNote(note)
@@ -290,7 +296,13 @@ const NoteView: React.FC<{ id: string; locale?: string }> = memo((props) => {
           },
         },
       })}
-      <NoteLayout title={title} date={note.createdAt} tips={tips} id={note.id}>
+      <NoteLayout
+        title={title}
+        date={note.createdAt}
+        tips={tips}
+        id={note.id}
+        titleMeta={<TranslationLanguageSelector content={note} />}
+      >
         {isSecret && !isLogged ? (
           <Banner type="warning" className="mt-4">
             {t('notPublicYet', { date: dateFormat })}
@@ -302,6 +314,7 @@ const NoteView: React.FC<{ id: string; locale?: string }> = memo((props) => {
                 {t('notPublic', { date: dateFormat })}
               </Banner>
             )}
+            <TranslationNotice content={note} />
             <XLogSummaryForNote id={props.id} locale={props.locale} />
 
             <BanCopy>
@@ -353,10 +366,15 @@ NoteView.displayName = 'NoteView'
 
 const PP: NextPage<NoteModelWithMeta | { needPassword: true; id: number }> = (props) => {
   const t = useTranslations('note')
+  const tTranslation = useTranslations('translation')
   const router = useRouter()
   const locale = useLocaleFromContext()
-  const prevLocale = useRef(locale)
-  const noteId = useNoteCollection((state) => state.get(props.id)?.id)
+  const noteId = useNoteCollection((state) =>
+    'needPassword' in props
+      ? state.get(props.id)?.id
+      : state.getLocalized(props.id, locale)?.id,
+  )
+  const propsLocale = 'needPassword' in props ? undefined : getContentLocale(props)
 
   const update = useUpdate()
   useEffect(() => {
@@ -366,8 +384,13 @@ const PP: NextPage<NoteModelWithMeta | { needPassword: true; id: number }> = (pr
   }, [noteId, update])
 
   useEffect(() => {
-    if (prevLocale.current === locale) return
-    prevLocale.current = locale
+    if (propsLocale) {
+      noteCollection.cacheLocalized(props as NoteModelWithMeta, propsLocale)
+    }
+  }, [props, propsLocale])
+
+  useEffect(() => {
+    if (noteId) return
     if ('needPassword' in props) {
       noteCollection.fetchById(props.id, undefined, {
         force: true,
@@ -378,7 +401,7 @@ const PP: NextPage<NoteModelWithMeta | { needPassword: true; id: number }> = (pr
     const nid = (props as NoteModelWithMeta).nid
     if (nid != null)
       noteCollection.fetchById(nid, undefined, { force: true, lang: locale })
-  }, [locale, props])
+  }, [locale, noteId, props])
 
   if ('needPassword' in props) {
     if (!noteId) {
@@ -400,9 +423,7 @@ const PP: NextPage<NoteModelWithMeta | { needPassword: true; id: number }> = (pr
   }
 
   if (!noteId) {
-    noteCollection.add(props)
-
-    return <Loading />
+    return <Loading loadingText={tTranslation('loading')} />
   }
 
   return <NoteView id={props.id} locale={locale} />
@@ -413,7 +434,7 @@ PP.getInitialProps = async (ctx) => {
   const password = ctx.query.password as string
   const locale = getLocaleFromContext(ctx)
   if (id == 'latest') {
-    return await noteCollection.fetchLatest()
+    return await noteCollection.fetchLatest(locale)
   }
   try {
     const res = await noteCollection.fetchById(

--- a/src/pages/[locale]/posts/[category]/[slug].tsx
+++ b/src/pages/[locale]/posts/[category]/[slug].tsx
@@ -18,6 +18,10 @@ import { wrapperNextPage } from '~/components/app/WrapperNextPage'
 import { KamiMarkdown } from '~/components/common/KamiMarkdown'
 import { OutdateNotice } from '~/components/in-page/Post/Outdate'
 import { PostRelated } from '~/components/in-page/Post/PostRelated'
+import {
+  TranslationLanguageSelector,
+  TranslationNotice,
+} from '~/components/in-page/Translation'
 import { ArticleLayout } from '~/components/layouts/ArticleLayout'
 import { Banner } from '~/components/ui/Banner'
 import { GgCoffee, PhBookOpen } from '~/components/ui/Icons/for-note'
@@ -49,6 +53,7 @@ import { getLocaleFromContext, Link, useRouter } from '~/i18n/navigation'
 import { useLocaleFromContext } from '~/provider/locale-context'
 import type { WithMeta } from '~/types/api-client'
 import { apiClient } from '~/utils/client'
+import { getContentLocale } from '~/utils/translation'
 import { isEqualObject } from '~/utils/_'
 import { isLikedBefore, setLikeId } from '~/utils/cookie'
 import { imagesRecord2Map } from '~/utils/images'
@@ -117,7 +122,7 @@ const useUpdatePost = (post: ModelWithDeleted<PostModelWithMeta>) => {
   ])
 }
 
-const Seo$: FC<{ id: string }> = ({ id }) => {
+const Seo$: FC<{ id: string; locale: string }> = ({ id, locale }) => {
   const {
     title,
     summary,
@@ -129,7 +134,7 @@ const Seo$: FC<{ id: string }> = ({ id }) => {
     images,
     meta,
   } = usePostCollection((state) =>
-    pick(state.data.get(id)!, [
+    pick((state.getLocalized(id, locale) ?? state.data.get(id))!, [
       'title',
       'summary',
       'createdAt',
@@ -161,12 +166,15 @@ const Seo$: FC<{ id: string }> = ({ id }) => {
   )
 }
 
-const FooterActionBar: FC<{ id: string }> = ({ id }) => {
+const FooterActionBar: FC<{ id: string; locale: string }> = ({ id, locale }) => {
   const t = useTranslations('post')
   const [actions, setActions] = useState<ActionProps>({})
 
   const post = usePostCollection(
-    (state) => state.data.get(id) || (noop as PostModelWithMeta),
+    (state) =>
+      state.getLocalized(id, locale) ??
+      state.data.get(id) ??
+      (noop as PostModelWithMeta),
   )
 
   const themeConfig = useThemeConfig()
@@ -260,8 +268,10 @@ const FooterActionBar: FC<{ id: string }> = ({ id }) => {
   )
 }
 
-const PostUpdateObserver: FC<{ id: string }> = memo(({ id }) => {
-  const post = usePostCollection((state) => state.data.get(id))
+const PostUpdateObserver: FC<{ id: string; locale: string }> = memo(({ id, locale }) => {
+  const post = usePostCollection(
+    (state) => state.getLocalized(id, locale) ?? state.data.get(id),
+  )
   useUpdatePost(post!)
   return null
 })
@@ -270,7 +280,7 @@ PostUpdateObserver.displayName = 'PostUpdateObserver'
 
 export const PostView: FC<IdProps & { locale?: string }> = (props) => {
   const post = usePostCollection(
-    (state) => state.data.get(props.id)!,
+    (state) => state.getLocalized(props.id, props.locale || 'zh')!,
     shallow,
   )
 
@@ -296,12 +306,13 @@ export const PostView: FC<IdProps & { locale?: string }> = (props) => {
   return (
     <>
       <AckRead type='post' id={post.id} />
-      <Seo$ id={post.id} />
+      <Seo$ id={post.id} locale={props.locale || 'zh'} />
       <ArticleLayout
         title={post.title}
         id={post.id}
         type="post"
         titleAnimate={false}
+        titleMeta={<TranslationLanguageSelector content={post} />}
       >
         {post.summary ? (
           <Banner
@@ -316,6 +327,7 @@ export const PostView: FC<IdProps & { locale?: string }> = (props) => {
           <XLogSummaryForPost id={post.id} locale={(props as { locale?: string }).locale} />
         )}
         <OutdateNotice time={post.modifiedAt || post.createdAt} />
+        <TranslationNotice content={post} />
         <ImageSizeMetaContext.Provider value={imagesMap}>
           <article>
             <h1 className="sr-only">{post.title}</h1>
@@ -334,7 +346,7 @@ export const PostView: FC<IdProps & { locale?: string }> = (props) => {
         ) : null}
 
         <XLogInfoForPost id={post.id} />
-        <FooterActionBar id={post.id} />
+        <FooterActionBar id={post.id} locale={props.locale || 'zh'} />
         <Suspense>
           <CommentLazy
             key={post.id}
@@ -346,31 +358,36 @@ export const PostView: FC<IdProps & { locale?: string }> = (props) => {
         <SearchFAB />
       </ArticleLayout>
 
-      <PostUpdateObserver id={post.id} />
+      <PostUpdateObserver id={post.id} locale={props.locale || 'zh'} />
     </>
   )
 }
 
 const NextPostView: NextPage<PostModelWithMeta> = (props) => {
   const { id } = props
+  const tTranslation = useTranslations('translation')
   const router = useRouter()
   const locale = useLocaleFromContext()
-  const prevLocale = useRef(locale)
-  const postId = usePostCollection((state) => state.data.get(id)?.id)
+  const post = usePostCollection((state) => state.getLocalized(id, locale))
+  const propsLocale = getContentLocale(props)
 
   useEffect(() => {
-    if (prevLocale.current === locale) return
-    prevLocale.current = locale
+    if (propsLocale) {
+      usePostCollection.getState().cacheLocalized(props, propsLocale)
+    }
+  }, [props, propsLocale])
+
+  useEffect(() => {
+    if (post) return
     const category = router.query.category as string
     const slug = router.query.slug as string
     if (category && slug) {
       usePostCollection.getState().fetchBySlug(category, slug, locale)
     }
-  }, [locale, router.query.category, router.query.slug])
+  }, [locale, post, router.query.category, router.query.slug])
 
-  if (!postId) {
-    usePostCollection.getState().add(props)
-    return <Loading />
+  if (!post) {
+    return <Loading loadingText={tTranslation('loading')} />
   }
 
   return <PostView id={id} locale={locale} />

--- a/src/pages/[locale]/timeline/index.tsx
+++ b/src/pages/[locale]/timeline/index.tsx
@@ -11,12 +11,14 @@ import { Seo } from '~/components/app/Seo'
 import { ArticleLayout } from '~/components/layouts/ArticleLayout'
 import { TimelineListWrapper } from '~/components/in-page/Timeline/TimelineListWrapper'
 import { SolidBookmark } from '~/components/ui/Icons/for-note'
+import { Loading } from '~/components/ui/Loading'
 import { NumberTransition } from '~/components/ui/NumberRecorder'
 import { TrackerAction } from '~/constants/tracker'
 import { useAnalyze } from '~/hooks/app/use-analyze'
 import { useDetectPadOrMobile } from '~/hooks/ui/use-viewport'
 import { getLocaleFromContext, Link, useRouter } from '~/i18n/navigation'
-import { apiClient, setRequestLocale } from '~/utils/client'
+import { useLocaleFromContext } from '~/provider/locale-context'
+import { apiClient } from '~/utils/client'
 import { springScrollToElement } from '~/utils/spring'
 import { dayOfYear, daysOfYear, secondOfDay, secondOfDays } from '~/utils/time'
 
@@ -24,6 +26,7 @@ import styles from './index.module.css'
 
 interface TimeLineViewProps extends TimelineData {
   memory: boolean
+  __contentLocale?: string
 }
 enum ArticleType {
   Post,
@@ -113,37 +116,36 @@ const Progress: FC = memo(() => {
 const TimeLineView: NextPage<TimeLineViewProps> = (props) => {
   const t = useTranslations('timeline')
   const router = useRouter()
+  const locale = useLocaleFromContext()
   const [timelineData, setTimelineData] = useState<TimeLineViewProps>(props)
-  const currentLocaleRef = useRef<string>(getLocaleFromContext({
-    pathname: router.pathname ?? '',
-    asPath: router.asPath ?? '',
-    query: router.query,
-  }))
+  const [contentLocale, setContentLocale] = useState(props.__contentLocale)
+  const requestIdRef = useRef(0)
 
   // Sync props into state when getInitialProps returns new data (e.g. client-side navigation)
   useEffect(() => {
-    setTimelineData(props)
-  }, [props])
+    if (props.__contentLocale === locale) {
+      setTimelineData(props)
+      setContentLocale(props.__contentLocale)
+    }
+  }, [locale, props])
 
   useEffect(() => {
-    const fetchingLocale = getLocaleFromContext({
-      pathname: router.pathname ?? '',
-      asPath: router.asPath ?? '',
-      query: router.query,
-    })
-    currentLocaleRef.current = fetchingLocale
-    setRequestLocale(fetchingLocale)
+    const requestId = ++requestIdRef.current
     const { type, year, memory } = router.query as any
     const TypeMap = { post: 0, note: 1 }
     const Type = TypeMap[type as keyof typeof TypeMap] as number | undefined
-    apiClient.aggregate.getTimeline({ type: Type, year }).then((payload: any) => {
-      if (currentLocaleRef.current !== fetchingLocale) return
+    apiClient.aggregate.proxy.timeline.get<{ data: TimelineData }>({
+      params: { type: Type, year, lang: locale },
+    }).then((payload) => {
+      if (requestId !== requestIdRef.current) return
       setTimelineData({
         ...payload.data,
         memory: !!memory,
+        __contentLocale: locale,
       } as TimeLineViewProps)
+      setContentLocale(locale)
     })
-  }, [router.pathname, router.asPath, router.query])
+  }, [locale, router.query])
 
   const sortedMap = new Map<number, MapType[]>()
   const { posts = [], notes = [] } = timelineData
@@ -248,16 +250,20 @@ const TimeLineView: NextPage<TimeLineViewProps> = (props) => {
   const isMobile = useDetectPadOrMobile()
 
   const totalCount = arr.flat(2).filter((i) => typeof i === 'object').length
-  const subtitleSuffix = !props.memory ? t('keepGoing') : t('lookBack')
+  const subtitleSuffix = !timelineData.memory ? t('keepGoing') : t('lookBack')
+
+  if (contentLocale !== locale) {
+    return <Loading />
+  }
 
   return (
     <ArticleLayout
-      title={!props.memory ? t('title') : t('memory')}
+      title={!timelineData.memory ? t('title') : t('memory')}
       subtitle={[t('totalArticles', { posts: totalCount, suffix: subtitleSuffix })]}
       delay={500}
-      key={props.memory ? 'memory' : 'timeline'}
+      key={timelineData.memory ? 'memory' : 'timeline'}
     >
-      {!props.memory && (
+      {!timelineData.memory && (
         <div className="text-shizuku-text -mt-12 mb-12">
           <Progress />
           <p>{t('livePresent')}</p>
@@ -331,13 +337,19 @@ TimeLineView.getInitialProps = async (ctx) => {
     post: TimelineType.Post,
     note: TimelineType.Note,
   }[type as any] as number | undefined
-  const payload = await apiClient.aggregate.getTimeline({
-    type: Type,
-    year,
+  const payload = await apiClient.aggregate.proxy.timeline.get<{
+    data: TimelineData
+  }>({
+    params: {
+      type: Type,
+      year,
+      lang: getLocaleFromContext(ctx),
+    },
   })
   return {
     ...payload.data,
     memory: !!memory,
+    __contentLocale: getLocaleFromContext(ctx),
   } as TimeLineViewProps
 }
 export default TimeLineView

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -21,7 +21,6 @@ import { InitialContextProvider } from '~/provider/initial-data'
 import { LangSyncProvider } from '~/provider/lang-sync'
 import { LocaleProvider } from '~/provider/locale-context'
 import { SWRProvider } from '~/provider/swr'
-import { setRequestLocale } from '~/utils/client'
 import { attachRequestProxy, fetchInitialData } from '~/utils/app'
 import { isDev } from '~/utils/env'
 
@@ -136,54 +135,45 @@ const App: FC<DataModel & { Component: any; pageProps: any; err: any }> = (
 // @ts-ignore
 App.getInitialProps = async (props: AppContext) => {
   const ctx = props.ctx
-  const request = ctx.req
-
-  attachRequestProxy(request)
+  attachRequestProxy(ctx.req)
 
   const locale = getLocaleFromContext(ctx)
-  setRequestLocale(locale)
-  try {
-    const data: InitialDataType & { reason?: any } = await fetchInitialData()
+  const data: InitialDataType & { reason?: any } = await fetchInitialData(locale)
 
-    const messages = (
-      await import(`../messages/${locale}.json`)
-    ).default as Record<string, unknown>
+  const messages = (
+    await import(`../messages/${locale}.json`)
+  ).default as Record<string, unknown>
 
-    const appProps = await (async () => {
-      try {
+  const appProps = await (async () => {
+    try {
         // Next 会从小组件向上渲染整个页面，有可能在此报错。兜底
-        return await NextApp.getInitialProps(props)
-      } catch (e) {
+      return await NextApp.getInitialProps(props)
+    } catch (e) {
         // TODO next rfc Layout, 出了就重构这里
         // 2023 tmd next rfc 全是大饼，根本没法用
         // 只有无数据 也就是 服务端不跑起来 或者接口不对的时候 捕获异常
         // 这是为什么呢 说来说去还是 nextjs 太辣鸡了 只能各种 hack
         // 只能这样了
 
-        if (!data.reason) {
+      if (!data.reason) {
           // 这里抛出，和官网直接 await getProps 一样，异常走到 _error 处理
-          throw e
-        }
-        // 这里捕获，为了走全局无数据页
-        if (ctx.res) {
-          ctx.res.statusCode = 466
-          ctx.res.statusMessage = 'No Data'
-        }
-        return null
+        throw e
       }
-    })()
-    return {
-      ...appProps,
-      initData: data,
-      locale,
-      messages,
-      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone || FALLBACK_TIME_ZONE,
-      now: Date.now(),
+        // 这里捕获，为了走全局无数据页
+      if (ctx.res) {
+        ctx.res.statusCode = 466
+        ctx.res.statusMessage = 'No Data'
+      }
+      return null
     }
-  } finally {
-    if (request) {
-      setRequestLocale(null)
-    }
+  })()
+  return {
+    ...appProps,
+    initData: data,
+    locale,
+    messages,
+    timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone || FALLBACK_TIME_ZONE,
+    now: Date.now(),
   }
 }
 

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -26,6 +26,7 @@ import Document, {
 } from 'next/document'
 
 import { attachRequestProxy, fetchInitialData } from '~/utils/app'
+import { getLocaleFromContext } from '~/i18n/navigation'
 
 interface MyDocumentProps extends DocumentInitialProps {
   customStylesheetHrefs: string[]
@@ -41,7 +42,7 @@ export default class MyDocument extends Document<MyDocumentProps> {
 
     let customStylesheetHrefs: string[] = []
     try {
-      const data = await fetchInitialData()
+      const data = await fetchInitialData(getLocaleFromContext(ctx))
       customStylesheetHrefs = data?.config?.site?.custom?.css || []
     } catch {
       customStylesheetHrefs = []

--- a/src/provider/initial-data.tsx
+++ b/src/provider/initial-data.tsx
@@ -2,15 +2,18 @@ import mergeWith from 'lodash-es/mergeWith'
 import type { FC } from 'react'
 import { createContext, memo, useEffect, useMemo } from 'react'
 
-import type { AggregateRoot } from '@mx-space/api-client'
+import type { AggregateRoot, PageModel } from '@mx-space/api-client'
 
 import { defaultConfigs } from '~/configs.default'
 import type { KamiConfig } from '~/types/config'
+import type { Locale } from '~/i18n/config'
 import { cloneDeep } from '~/utils/_'
 
 export type InitialDataType = {
   aggregateData: AggregateRoot
   config: KamiConfig
+  pageMeta: Pick<PageModel, 'id' | 'slug' | 'title'>[]
+  locale: Locale
 }
 export const InitialContext = createContext({} as InitialDataType)
 
@@ -27,7 +30,7 @@ export const InitialContextProvider: FC<{ value: InitialDataType }> = memo(
           }
         },
       ) as KamiConfig
-    }, [])
+    }, [props.value.config])
     useEffect(() => {
       window.data = { ...props.value, config: mergeThemeConfig }
     }, [mergeThemeConfig, props.value])

--- a/src/provider/lang-sync.tsx
+++ b/src/provider/lang-sync.tsx
@@ -7,10 +7,9 @@ import { useLocaleFromContext } from '~/provider/locale-context'
 import { setRequestLocale } from '~/utils/client'
 
 /**
- * Syncs current locale to API client so requests include x-lang header.
- * Backend can return localized content (e.g. Shiroi / mx-space).
- * useLayoutEffect ensures x-lang is set before child useEffects (e.g. posts fetch) run.
- * Reads locale from LocaleContext (single source of truth) so x-lang matches UI.
+ * Keeps the compatibility `x-lang` header synchronized with the URL locale.
+ * The request interceptor also reads the URL directly, so child effects cannot
+ * race this provider during a locale switch.
  */
 export const LangSyncProvider: FC<PropsWithChildren<object>> = ({ children }) => {
   const locale = useLocaleFromContext()

--- a/src/provider/locale-context.tsx
+++ b/src/provider/locale-context.tsx
@@ -5,7 +5,7 @@
  * - Source: current URL only (pathname/asPath). No separate locale store.
  * - Read: server use getLocaleFromContext(ctx); components use useLocaleFromContext() or useLocale().
  * - Write: use Link from ~/i18n/navigation (href + as are localized); programmatic use useRouter().push(pathname, { locale }).
- * - API: setRequestLocale is set only by _app getInitialProps and LangSyncProvider. Components do not call setRequestLocale.
+ * - API: the browser request interceptor derives `lang` from the URL; LangSyncProvider keeps `x-lang` for compatibility.
  */
 
 import React, {
@@ -26,7 +26,7 @@ const LocaleContext = createContext<Locale>(defaultLocale)
  * Provider that supplies the current locale as global state.
  * - Server / first paint: uses initialLocale from _app (getLocaleFromContext in getInitialProps).
  * - Client: uses router (useLocale from i18n/navigation) so locale stays in sync with URL.
- * All components and API request layer (setRequestLocale) should consume this for a single source of truth.
+ * All components and the API request layer should consume this for a single source of truth.
  */
 export const LocaleProvider: FC<
   PropsWithChildren<{ initialLocale: Locale }>

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -60,6 +60,10 @@ export interface SecondaryColor {
   dark: string
 }
 interface Site {
+  /** Optional localized brand copy, provided by theme/<name>.<locale> overlays. */
+  title?: string | null
+  description?: string | null
+  introduction?: string | null
   themeColor?: ThemeColor | string
   secondaryColor?: SecondaryColor | string
   favicon: string

--- a/src/utils/app.ts
+++ b/src/utils/app.ts
@@ -1,12 +1,13 @@
 import type { IncomingMessage } from 'http'
 import { version } from 'react'
 
-import type { AggregateRoot } from '@mx-space/api-client'
+import type { AggregateRootWithTheme, PageModel } from '@mx-space/api-client'
 
 import { defaultConfigs } from '~/configs.default'
 import type { KamiConfig } from '~/types/config'
 import { $axios, apiClient } from '~/utils/client'
 import { isClientSide, isServerSide } from '~/utils/env'
+import type { Locale } from '~/i18n/config'
 
 import PKG from '../../package.json'
 import type { InitialDataType } from '../provider'
@@ -38,21 +39,23 @@ export const attachRequestProxy = (request?: IncomingMessage) => {
 
 }
 
-export async function fetchInitialData(): Promise<InitialDataType> {
-  if (isClientSide() && window.data) {
+export async function fetchInitialData(locale: Locale): Promise<InitialDataType> {
+  if (isClientSide() && window.data?.locale === locale) {
     return window.data
   }
 
-  const [aggregateDataState, configSnippetState] = await Promise.allSettled([
-    apiClient.aggregate.getAggregateData(),
-    apiClient.snippet.getByReferenceAndName<KamiConfig>(
-      'theme',
-      process.env.NEXT_PUBLIC_SNIPPET_NAME || 'kami',
-    ),
-  ])
+  const themeName = process.env.NEXT_PUBLIC_SNIPPET_NAME || 'kami'
+  const [aggregateDataState, pageMetaState] =
+    await Promise.allSettled([
+      apiClient.aggregate.proxy.get<AggregateRootWithTheme<KamiConfig>>({
+        params: { theme: themeName, lang: locale },
+      }),
+      apiClient.page.getList(1, 20, { select: ['id', 'slug', 'title'] }),
+    ])
 
-  let aggregateData: AggregateRoot | null = null
+  let aggregateData: AggregateRootWithTheme<KamiConfig> | null = null
   let configSnippet: KamiConfig | null = null
+  let pageMeta: Pick<PageModel, 'id' | 'slug' | 'title'>[] = []
   let reason = undefined as undefined | string
   if (aggregateDataState.status === 'fulfilled') {
     aggregateData = aggregateDataState.value
@@ -62,12 +65,18 @@ export async function fetchInitialData(): Promise<InitialDataType> {
     console.error(`Fetch aggregate data error: ${aggregateDataState.reason}`)
   }
 
-  if (configSnippetState.status === 'fulfilled') {
-    configSnippet = { ...configSnippetState.value }
+  if (aggregateDataState.status === 'fulfilled') {
+    configSnippet = aggregateDataState.value.theme
+      ? { ...aggregateDataState.value.theme }
+      : (defaultConfigs as unknown as KamiConfig)
   } else {
     configSnippet = defaultConfigs as any
   }
 
+  if (pageMetaState.status === 'fulfilled') {
+    pageMeta = pageMetaState.value.data
+  }
+
   // @ts-ignore
-  return { aggregateData, config: configSnippet, reason }
+  return { aggregateData, config: configSnippet, pageMeta, locale, reason }
 }

--- a/src/utils/client.ts
+++ b/src/utils/client.ts
@@ -3,6 +3,7 @@ import { CanceledError } from 'axios'
 import { message } from 'react-message-popup'
 
 import { allControllers, createClient } from '@mx-space/api-client'
+import { defaultLocale, enabledLocaleSet } from '~/i18n/config'
 import { isClientSide } from './env'
 import { API_URL } from '~/constants/env'
 
@@ -33,10 +34,19 @@ export const $axios = axiosAdaptor.default as AxiosInstance
 $axios.defaults.timeout = 10000
 $axios.defaults.withCredentials = true
 
-/** Current locale for API requests (set by LangSyncProvider). Backend can use x-lang for localized content. */
+/**
+ * Current browser locale for API requests (set by LangSyncProvider).
+ *
+ * This value is deliberately client-only: a module global is unsafe for
+ * concurrent SSR. Server callers must pass `lang` with the individual
+ * request instead.
+ */
 let requestLocale: string | null = null
 
 export function setRequestLocale(locale: string | null) {
+  if (!isClientSide()) {
+    return
+  }
   requestLocale = locale
 }
 
@@ -44,11 +54,26 @@ export function getRequestLocale() {
   return requestLocale
 }
 
+const getBrowserUrlLocale = () => {
+  if (!isClientSide()) {
+    return null
+  }
+  const firstPathSegment = window.location.pathname.split('/').filter(Boolean)[0]
+  return firstPathSegment && enabledLocaleSet.has(firstPathSegment)
+    ? firstPathSegment
+    : defaultLocale
+}
+
 $axios.interceptors.request.use((config) => {
   config.headers = config.headers ?? {}
   config.headers['x-uuid'] = uuid
-  if (requestLocale) {
-    config.headers['x-lang'] = requestLocale
+  const isGetRequest = (config.method ?? 'get').toLowerCase() === 'get'
+  const locale = getBrowserUrlLocale() ?? requestLocale
+  if (locale) {
+    config.headers['x-lang'] = locale
+    if (isGetRequest) {
+      config.params = { ...config.params, lang: config.params?.lang ?? locale }
+    }
   } else if ('x-lang' in config.headers) {
     delete config.headers['x-lang']
   }

--- a/src/utils/client.ts
+++ b/src/utils/client.ts
@@ -64,6 +64,19 @@ const getBrowserUrlLocale = () => {
     : defaultLocale
 }
 
+const hasLangParam = (params: unknown) => {
+  if (params instanceof URLSearchParams) {
+    return params.has('lang')
+  }
+  if (typeof params === 'string') {
+    return /(?:^|[?&])lang=/.test(params)
+  }
+  return !!params && typeof params === 'object' && 'lang' in params
+}
+
+const urlHasLangParam = (url: string | undefined) =>
+  !!url && /[?&]lang=/.test(url)
+
 $axios.interceptors.request.use((config) => {
   config.headers = config.headers ?? {}
   config.headers['x-uuid'] = uuid
@@ -71,8 +84,12 @@ $axios.interceptors.request.use((config) => {
   const locale = getBrowserUrlLocale() ?? requestLocale
   if (locale) {
     config.headers['x-lang'] = locale
-    if (isGetRequest) {
-      config.params = { ...config.params, lang: config.params?.lang ?? locale }
+    if (
+      isGetRequest &&
+      !hasLangParam(config.params) &&
+      !urlHasLangParam(config.url)
+    ) {
+      config.params = { ...config.params, lang: locale }
     }
   } else if ('x-lang' in config.headers) {
     delete config.headers['x-lang']

--- a/src/utils/translation.ts
+++ b/src/utils/translation.ts
@@ -1,0 +1,70 @@
+type UnknownRecord = Record<string, unknown>
+
+export type ContentTranslation = {
+  isTranslated: boolean
+  sourceLang?: string
+  targetLang?: string
+  availableTranslations: string[]
+}
+
+const asRecord = (value: unknown): UnknownRecord | undefined =>
+  value && typeof value === 'object' ? (value as UnknownRecord) : undefined
+
+const asString = (value: unknown): string | undefined =>
+  typeof value === 'string' && value.trim() ? value : undefined
+
+const asStringArray = (value: unknown): string[] =>
+  Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string' && !!item)
+    : []
+
+/**
+ * Normalizes both the typed Core fields and older response metadata shapes.
+ * A missing field remains unknown: callers must never infer an original
+ * language from the requested locale.
+ */
+export function getContentTranslation(content: unknown): ContentTranslation {
+  const record = asRecord(content) ?? {}
+  const responseMeta = asRecord(record.$meta)
+  const raw = asRecord(record.$raw)
+  const rawMeta = asRecord(raw?.$meta)
+  const translationMeta =
+    asRecord(record.translationMeta) ??
+    asRecord(responseMeta?.translationMeta) ??
+    asRecord(responseMeta?.translation) ??
+    asRecord(rawMeta?.translationMeta) ??
+    asRecord(rawMeta?.translation)
+
+  const isTranslated =
+    record.isTranslated === true ||
+    responseMeta?.isTranslated === true ||
+    rawMeta?.isTranslated === true
+  const sourceLang =
+    asString(record.sourceLang) ??
+    asString(responseMeta?.sourceLang) ??
+    asString(translationMeta?.sourceLang)
+  const targetLang =
+    asString(record.targetLang) ??
+    asString(responseMeta?.targetLang) ??
+    asString(translationMeta?.targetLang)
+  const availableTranslations = Array.from(
+    new Set([
+      ...asStringArray(record.availableTranslations),
+      ...asStringArray(responseMeta?.availableTranslations),
+      ...asStringArray(rawMeta?.availableTranslations),
+    ]),
+  )
+
+  return { isTranslated, sourceLang, targetLang, availableTranslations }
+}
+
+export type LocalizedContent = {
+  /** Private client cache marker; this is not a Core model field. */
+  __contentLocale?: string
+}
+
+export const getContentLocale = (content: unknown) =>
+  asString(asRecord(content)?.__contentLocale)
+
+export const withContentLocale = <T extends object>(content: T, locale: string) =>
+  ({ ...content, __contentLocale: locale }) as T & LocalizedContent


### PR DESCRIPTION
## Summary

Cherry-picks two locale-related commits from my fork onto upstream/master:

- **feat: improve localized content experience** (3d528ca6):
  - Localized content for home / posts / notes / timeline pages based on locale
  - `fetchInitialData(locale)`: fetches the aggregate endpoint with `theme` + `lang` params to get theme config in one request, and injects `pageMeta` (for the home pages dropdown) and `locale` into `InitialDataType`
  - New `Translation` component and `src/utils/translation.ts` for displaying note/post translations
  - Axios interceptor automatically appends the `lang` query param and `x-lang` header to GET requests
- **fix: avoid duplicate locale query parameters** (751e54f1): fixes the interceptor duplicating the `lang` param when the request already carries one

## Conflict resolution

Cherry-picking conflicted in `src/utils/app.ts` and `src/provider/initial-data.tsx` (upstream's `fetchInitialData` fetches config differently than my fork). Resolved in favor of this PR's intent: keep the aggregate call with `theme`/`lang` params. Verified that `AggregateRootWithTheme`, `page.getList(page, perPage, { select })`, and `aggregate.proxy.get` all exist in the `@mx-space/api-client@4.0.0` version pinned upstream.

## Notes

- Theme config is no longer fetched separately via the snippet API; it now comes from the aggregate endpoint's `theme` param (requires mx-server support; this matches what's running in production on my fork)
- `config.init.yaml` documents two new config options
