### PR TITLE
fix: add top spacing to translation banner

### DIFF
--- a/src/components/in-page/Translation/index.tsx
+++ b/src/components/in-page/Translation/index.tsx
@@ -88,7 +88,12 @@ export const TranslationNotice: FC<{ content: unknown }> = ({ content }) => {
 
   if (translation.isTranslated && sourceLang && targetLang) {
     return (
-      <Banner type="info" placement="left" className="mb-6" showIcon={false}>
+      <Banner
+        type="info"
+        placement="left"
+        className="mt-4 mb-6"
+        showIcon={false}
+      >
         <div className="flex w-full flex-wrap items-center gap-x-3 gap-y-2">
           <strong>{t('aiTranslation')}</strong>
           <span>
@@ -116,7 +121,12 @@ export const TranslationNotice: FC<{ content: unknown }> = ({ content }) => {
 
   if (sourceLang && sourceLang !== locale) {
     return (
-      <Banner type="info" placement="left" className="mb-6" showIcon={false}>
+      <Banner
+        type="info"
+        placement="left"
+        className="mt-4 mb-6"
+        showIcon={false}
+      >
         <span>
           {t('originalContent', { language: t(getLanguageNameKey(sourceLang)) })}
         </span>

--- a/src/pages/[locale]/notes/[id].tsx
+++ b/src/pages/[locale]/notes/[id].tsx
@@ -29,10 +29,7 @@ import { NoteFooterNavigationBarForMobile } from '~/components/in-page/Note/Note
 import { NoteMarkdownRender } from '~/components/in-page/Note/NoteMarkdownRender'
 import { NotePasswordConfrim } from '~/components/in-page/Note/NotePasswordConfirm'
 import { BanCopy } from '~/components/in-page/Note/WarningOverlay/ban-copy'
-import {
-  TranslationLanguageSelector,
-  TranslationNotice,
-} from '~/components/in-page/Translation'
+import { TranslationNotice } from '~/components/in-page/Translation'
 import { NoteLayout } from '~/components/layouts/NoteLayout'
 import { Banner } from '~/components/ui/Banner'
 import { ImageSizeMetaContext } from '~/components/ui/Image/context'
@@ -301,7 +298,6 @@ const NoteView: React.FC<{ id: string; locale?: string }> = memo((props) => {
         date={note.createdAt}
         tips={tips}
         id={note.id}
-        titleMeta={<TranslationLanguageSelector content={note} />}
       >
         {isSecret && !isLogged ? (
           <Banner type="warning" className="mt-4">


### PR DESCRIPTION
## Summary

- Add `mt-4` top margin to the translation notice banner (`TranslationNotice`) so it is no longer crowded against the title on both note and post pages
- Drop the language selector (`TranslationLanguageSelector`) from the note title meta since the notice banner already covers switching back to the original language via "View Original"

Both banner states (translated "AI Translation" notice and original-language notice) get the extra spacing.

## Test plan

- Open a note/post whose locale differs from the content's source language
- Verify the banner sits with comfortable spacing below the title